### PR TITLE
Removes setting fields to none and background to bold

### DIFF
--- a/colors/meta5.vim
+++ b/colors/meta5.vim
@@ -16,25 +16,25 @@ let colors_name = "meta5"
 if version >= 700
   hi CursorLine   guibg=#1c1c1c gui=none ctermbg=234 cterm=none
   hi CursorColumn guibg=#303030 ctermbg=236
-  hi MatchParen   guifg=#ffaf00 guibg=bold gui=bold ctermfg=214 ctermbg=none cterm=bold
+  hi MatchParen   guifg=#ffaf00 ctermfg=214 
   hi Pmenu        guifg=#eeeeee guibg=#444444 ctermfg=255 ctermbg=238
   hi PmenuSel     guifg=#000000 guibg=#df8700 ctermfg=0 ctermbg=172
-  hi search       guifg=#ff00ff guibg=none gui=underline ctermfg=201 ctermbg=none cterm=underline
-  hi Incsearch    guifg=#ff00ff guibg=none gui=underline ctermfg=201 ctermbg=none cterm=underline
+  hi search       guifg=#ff00ff gui=underline ctermfg=201 cterm=underline
+  hi Incsearch    guifg=#ff00ff gui=underline ctermfg=201 cterm=underline
 endif
 
 " General colors
 hi Cursor         guibg=#585858 ctermbg=240
 hi NonText        guifg=#5f5fff ctermfg=63
 hi Normal         guifg=#bcbcbc guibg=#121212 ctermfg=250 ctermbg=233
-hi LineNr         guifg=#808080 guibg=none ctermfg=244 ctermbg=none
+hi LineNr         guifg=#808080 ctermfg=244 
 hi StatusLine     guifg=#080808 guibg=#9e9e9e ctermfg=232 ctermbg=247
 hi StatusLineNC   guifg=#080808 guifg=#585858 ctermfg=232 ctermbg=240
 hi VertSplit      guifg=#444444 guibg=#585858 ctermfg=238 ctermbg=240
 hi Folded         guifg=#a8a8a8 guibg=#000080 ctermfg=248 ctermbg=4
 hi Title          guifg=#df8700 ctermfg=172
 hi Visual         guifg=#afffff guibg=#4e4e4e gui=bold ctermfg=159 ctermbg=239 cterm=bold
-hi SpecialKey     guifg=#808080 ctermfg=244 guibg=none ctermbg=none
+hi SpecialKey     guifg=#808080 ctermfg=244 
 
 " Syntax highlighting
 hi Comment        guifg=#808080 ctermfg=244
@@ -51,7 +51,7 @@ hi Structure      guifg=#00dfdf ctermfg=44
 hi Label          guifg=#df5f00 ctermfg=202
 hi Statement      guifg=#5fdfff ctermfg=81
 hi Operator       guifg=#8787ff ctermfg=105
-hi Keyword        guifg=#dfffff guibg=none gui=bold ctermfg=195 ctermbg=none  cterm=bold
+hi Keyword        guifg=#dfffff gui=bold ctermfg=195 cterm=bold
 hi Constant       guifg=#af5fff ctermfg=195
 hi Number         guifg=#5fdf5f ctermfg=77
 hi Special        guifg=#5fdf5f gui=bold ctermfg=77 cterm=bold
@@ -62,10 +62,9 @@ hi Define         guifg=#ff8700 ctermfg=208
 hi javaTypedef    guifg=#87ff5f ctermfg=129
 
 "diff
-hi DiffAdd        cterm=none ctermfg=46 ctermbg=22 gui=none guifg=#00ff00 guibg=#005f00
-hi DiffDelete     cterm=none ctermfg=160 ctermbg=52 gui=none guifg=#df0000 guibg=#5f0000
-hi DiffChange     cterm=none ctermfg=none ctermbg=none gui=none guifg=none guibg=none
-hi DiffText       cterm=bold ctermfg=none ctermbg=20 gui=bold guifg=none guibg=#0000df
+hi DiffAdd        ctermfg=46 ctermbg=22 guifg=#00ff00 guibg=#005f00
+hi DiffDelete     ctermfg=160 ctermbg=52 guifg=#df0000 guibg=#5f0000
+hi DiffText       cterm=bold ctermbg=20 gui=bold guibg=#0000df
 
 "spell
 hi spellBad       guifg=#5f0000 guibg=#585858 ctermfg=52 ctermbg=240 cterm=underline


### PR DESCRIPTION
Hello! This is my first attempt at all at trying to contribute to someone else's github, so I'm sorry if this help wasn't wanted. I really like your colorscheme, but I have to use gVim at work on a windows computer. Every time gVim opens, it complains (attached below) about the fields that are set to none and on line 19 some fields set to bold. I felt like these fields weren't actually influencing the scheme and sure enough, when I removed them the errors went away and I could happily load gVim with your awesome scheme. I figured I would share this change so that other gVim users could enjoy the improvement. Once again, sorry if I instead actually broke something or these fields are needed in console vim, but I figured this was the easy start I was looking for in OSS.
- mt

The error list:
Error detected while processing C:\Users\mt\vim\vimfiles\bundle\meta5\c
olors\meta5.vim:

line   19:

E254: Cannot allocate color bold

line   30:

E254: Cannot allocate color none

line   37:

E254: Cannot allocate color none

line   54:

E254: Cannot allocate color none

line   67:

E254: Cannot allocate color none

E254: Cannot allocate color none

line   68:

E254: Cannot allocate color none

line   19:

E254: Cannot allocate color bold

line   30:

E254: Cannot allocate color none

line   37:

E254: Cannot allocate color none

line   54:

E254: Cannot allocate color none

line   67:

E254: Cannot allocate color none

E254: Cannot allocate color none

line   68:

E254: Cannot allocate color none

Error detected while processing function gitgutter#highlight#define_highlig
hts:

line    5:

E254: Cannot allocate color none

line    6:

E254: Cannot allocate color none

line    7:

E254: Cannot allocate color none

line   10:

E254: Cannot allocate color none

line   11:

E254: Cannot allocate color none

line   12:

E254: Cannot allocate color none

E254: Cannot allocate color none

E254: Cannot allocate color none

E254: Cannot allocate color none

E254: Cannot allocate color none

E254: Cannot allocate color none

E254: Cannot allocate color bold

E254: Cannot allocate color none

E254: Cannot allocate color none

E254: Cannot allocate color none

E254: Cannot allocate color none

E254: Cannot allocate color none

E254: Cannot allocate color none

E254: Cannot allocate color none

![gvimerror](https://cloud.githubusercontent.com/assets/3476403/9595037/0dc08484-5029-11e5-980a-20108f4e9e09.PNG)
